### PR TITLE
Fixes index.htm asset src location

### DIFF
--- a/src/web/admin/vue.config.js
+++ b/src/web/admin/vue.config.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const path = require('path')
+
+// https://cli.vuejs.org/config/#vue-config-js
+module.exports = {
+  // https://cli.vuejs.org/config/#publicpath
+  publicPath: '/admin',
+  // https://cli.vuejs.org/config/#devserver-proxy
+  // devServer: {
+  //   proxy: {
+  //     '/': {
+  //       target: "<url>",
+  //       ws: true,
+  //       changeOrigin: true
+  //     }
+  //   }
+  // }
+}


### PR DESCRIPTION
This PR seeks to fix the src location for our assets used in the index.html page; we use the 'admin' prefix in the URL. Additionally, I added settings to proxy any requests to '/' to the nodejs express endpoint for our 'API'.