### PR TITLE
Adding the ability to reload overlays on deployments. Closes #67

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # number-one
 
-<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+![CI](https://github.com/builders-club/number-one/workflows/CI/badge.svg?branch=main) <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-10-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 

--- a/src/web/overlays/wwwroot/js/alerts.js
+++ b/src/web/overlays/wwwroot/js/alerts.js
@@ -169,6 +169,10 @@ const app = new Vue({
       this.addAlert('onDonation', onDonationEvent);
     });
 
+    this.socket.on('reconnect', () => {
+      window.location.reload();
+    });
+
     console.log("We're loaded and listening the socket.io hub");
 
     setInterval(this.onInterval, 2000);

--- a/src/web/overlays/wwwroot/js/chat.js
+++ b/src/web/overlays/wwwroot/js/chat.js
@@ -58,6 +58,11 @@ const app = new Vue({
     this.socket.on('onChatMessage', onChatMessageEvent => {
       this.addMessage(onChatMessageEvent);
     });
+
+    this.socket.on('reconnect', () => {
+      window.location.reload();
+    });
+
     console.log("We're loaded and listening to 'onChatMessage' from socket.io");
   },
   template: '<div class="chat"><transition-group name="list" @after-leave="checkOverflow"><chatMessage v-for="(message, index) in messages" :key="message.id" :onChatMessageEvent="message" :ind="index" :total="messages.length" v-on:removeItem="removeItem" ref="message"></chatMessage></transition></div>'


### PR DESCRIPTION
This change should cause overlay browsers to reload on reconnect to socket.io.  This would mean on new deployments, once the overlay reconnects, the page will refresh.