### PR TITLE
Fix assets in debug

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import qs from 'querystring'
 import { Config, TwitchTokenResponse } from './models'
 import { ChatMonitor } from './chat'
 import { webhookRouter } from './webhooks'
-import { overlayRouter } from './web'
+import { overlayRouter, assetsRouter } from './web'
 import { log, LogLevel } from './common'
 import { Fauna, Twitch } from './integrations'
 import { IO } from './hub'
@@ -67,6 +67,10 @@ async function init(response: AxiosResponse<TwitchTokenResponse>) {
   app.use('/webhooks', webhookRouter)
 
   app.use('/overlays', overlayRouter)
+
+  if (process.env.NODE_ENV && process.env.NODE_ENV === 'development') {
+    app.use('/overlays/assets', assetsRouter)
+  }
 
   server.listen(port, () => {
     log(LogLevel.Info, `Server is listening on port ${port}`)

--- a/src/web/assets.ts
+++ b/src/web/assets.ts
@@ -1,0 +1,10 @@
+// This route is for debug purposes only. Once built, the assets folder will be available
+// directly to the express server.
+import express from 'express';
+import path from 'path'
+
+export const assetsRouter: express.Router = express.Router()
+const p = path.join(__dirname,'../../', 'assets')
+assetsRouter.use(
+  express.static(p)
+)

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -1,1 +1,2 @@
 export * from './overlays'
+export * from './assets'


### PR DESCRIPTION
While debugging, assets fail to play because express doesn't know where the 'assets' are.  This fix seeks to solve that problem.

![image](https://user-images.githubusercontent.com/8602418/98429170-ede02500-2059-11eb-834b-28554c671d26.png)
